### PR TITLE
Changed style to adhere to POSIX standard

### DIFF
--- a/bcn
+++ b/bcn
@@ -2,23 +2,22 @@
 
 #bcn, Bluetooth Connect
 
-
 device_amount=$(bluetoothctl devices | wc -l)
 
-if [[ $device_amount = 1 ]]; then
+if [ $device_amount = 1 ]; then
 	MAC=$(bluetoothctl devices | awk {'print $2'})
 		[ -z $MAC ] && MAC=NoDeviceFound # Prevents accidental disconnect error
 else
 	select=$(bluetoothctl devices | awk {'print $3'} | dmenu -l 10 -fn Monospace-15)
-	MAC=$(bluetoothctl devices | grep $select | awk {'print $2'}) 
+	MAC=$(bluetoothctl devices | grep $select | awk {'print $2'})
 		[ -z $MAC ] && MAC=NoDeviceFound # Prevents accidental disconnect error
 fi
 
 connect=$(bluetoothctl info $MAC | grep Connected: | awk '{print $2}')
-if [[ $connect = no ]]; then 
+if [ $connect = no ]; then
 	notify-send "Attempting to connect to $select"
 	bluetoothctl connect $MAC || notify-send "Failed to Connect"
-elif [[ $connect = yes ]]; then
+elif [ $connect = yes ]; then
 	notify-send "Attempting to disconnect $select"
-	bluetoothctl disconnect $MAC 
+	bluetoothctl disconnect $MAC
 fi


### PR DESCRIPTION
I recently came across your wonderful script! Thanks for this, it makes bluetooth connectivity on minimalist systems so much easier.

One modification I might add is to fix the conditional statements to adhere to the POSIX standard (you perhaps have set `/bin/sh` to symlink to bash). This modification makes portability much easier to systems with `/bin/sh` symlinked to other shells. :)